### PR TITLE
Harden block change handling and scheduling

### DIFF
--- a/src/src/poc/mempool/manager/Mempool.ts
+++ b/src/src/poc/mempool/manager/Mempool.ts
@@ -208,16 +208,23 @@ export class Mempool extends Logger {
 
                 this.fullSync = false;
 
-                await this.onBlockChange(currentBitcoinHeight);
+                // Only refresh challenges when close to the tip. During initial
+                // sync or reindexing the indexer is far behind so epoch data
+                // does not exist at the tip, fetching challenges would produce
+                // an empty set and the guard in watchBlockChanges would prevent
+                // any refresh until the indexer fully catches up.
+                if (blockDiff <= 10n) {
+                    await this.onBlockChange(currentBitcoinHeight);
+                }
             }
-
-            setTimeout(() => {
-                void this.verifyBlockHeight();
-            }, 5000);
         } catch (e) {
             if (Config.DEBUG_LEVEL >= DebugLevel.WARN) {
                 this.warn(`Error verifying block height: ${(e as Error).message}`);
             }
+        } finally {
+            setTimeout(() => {
+                void this.verifyBlockHeight();
+            }, 5000);
         }
     }
 
@@ -231,9 +238,12 @@ export class Mempool extends Logger {
             // clobbering `fullSync` with stale data.
             this.latestObservedHeight = blockHeight;
 
-            if (OPNetConsensus.getBlockHeight() <= blockHeight) {
-                await this.onBlockChange(blockHeight);
-            }
+            // Always refresh challenge solutions when the indexer progresses.
+            // The previous guard (OPNetConsensus.getBlockHeight() <= blockHeight)
+            // would skip refreshes during sync because verifyBlockHeight pushed
+            // the consensus height to the Bitcoin tip while the indexer was
+            // still far behind, leaving challenges permanently empty.
+            await this.onBlockChange(blockHeight);
 
             // A newer callback may have arrived during onBlockChange (which
             // can take seconds when the underlying challenge-solution fetch
@@ -274,19 +284,42 @@ export class Mempool extends Logger {
     }
 
     private async onBlockChange(blockHeight: bigint): Promise<void> {
+        // Only move the consensus height forward, never backwards.
+        if (OPNetConsensus.getBlockHeight() <= blockHeight) {
+            try {
+                OPNetConsensus.setBlockHeight(blockHeight);
+            } catch (e) {
+                if (Config.DEBUG_LEVEL >= DebugLevel.WARN) {
+                    this.warn(
+                        `Failed to set block height to ${blockHeight}: ${(e as Error).message}`,
+                    );
+                }
+            }
+        }
+
+        this.log(`[MEM] Block changed to height ${blockHeight}`);
+
         try {
-            OPNetConsensus.setBlockHeight(blockHeight);
-
-            this.log(`[MEM] Block changed to height ${blockHeight}`);
-
             await this.transactionVerifier.onBlockChange(blockHeight);
+        } catch (e) {
+            if (Config.DEBUG_LEVEL >= DebugLevel.WARN) {
+                this.warn(
+                    `Failed to refresh challenge solutions at ${blockHeight}: ${(e as Error).message}`,
+                );
+            }
+        }
 
-            /*if (Config.MEMPOOL.ENABLE_BLOCK_PURGE) {
-                void this.mempoolRepository.purgeOldTransactions(blockHeight);
-            }*/
+        /*if (Config.MEMPOOL.ENABLE_BLOCK_PURGE) {
+            void this.mempoolRepository.purgeOldTransactions(blockHeight);
+        }*/
 
+        try {
             await this.estimateFees();
-        } catch {}
+        } catch (e) {
+            if (Config.DEBUG_LEVEL >= DebugLevel.WARN) {
+                this.warn(`Failed to estimate fees: ${(e as Error).message}`);
+            }
+        }
     }
 
     private processSmartFee(feeData: SmartFeeEstimation): number {


### PR DESCRIPTION
## Description

Avoid refreshing challenge solutions while the indexer is far behind by only calling onBlockChange when the block is within 10 blocks of the tip. Ensure verifyBlockHeight is always re-scheduled by moving the timeout into a finally block. Always trigger onBlockChange when the indexer progresses (remove the stale guard), but only advance OPNetConsensus height forward and swallow/set warnings on failures. Wrap transactionVerifier.onBlockChange and fee estimation in try/catch blocks to log warnings instead of failing the flow. Kept the old block-purge code commented.

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Performance improvement
- [ ] Consensus change (changes that affect state calculation or validation)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] CI/CD changes
- [ ] Dependencies update

## Checklist

### Build & Tests

- [ ] `npm install` completes without errors
- [ ] `npm run build` completes without errors
- [ ] `npm test` passes all tests

### Code Quality

- [ ] Code follows the project's coding standards
- [ ] No new compiler warnings introduced
- [ ] Error handling is appropriate
- [ ] Logging is appropriate for debugging and monitoring

### Documentation

- [ ] Code comments added for complex logic
- [ ] Public APIs are documented
- [ ] README updated (if applicable)

### Security

- [ ] No sensitive data (keys, credentials) committed
- [ ] No new security vulnerabilities introduced
- [ ] RPC endpoints properly authenticated
- [ ] Input validation in place for external data

### OP_NET Node Specific

- [ ] Changes are compatible with existing network state
- [ ] Consensus logic changes are documented and tested
- [ ] State transitions are deterministic
- [ ] WASM VM execution is reproducible across nodes
- [ ] P2P protocol changes are backward-compatible (or migration planned)
- [ ] Database schema changes include migration path
- [ ] Epoch finality and PoC/PoW logic unchanged (or documented if changed)

## Testing

<!-- Describe how you tested these changes -->

## Consensus Impact

<!-- If this PR affects consensus, describe the impact and testing methodology -->

## Related Issues

<!-- Link any related issues: Fixes #123, Relates to #456 -->

---
By submitting this PR, I confirm that my contribution is made under the terms of the project's license.
