### PR TITLE
feat: Add UNLINK_THREAD for purging dead MessagePorts

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
         "compile": "tsgo -p tsconfig.json",
         "typecheck": "tsgo -p tsconfig.json --noEmit",
         "test": "vitest",
-        "setup": "npm i && npm run build"
+        "setup": "npm i && npm run build",
+        "postinstall": "patch-package"
     },
     "engines": {
         "node": ">=24.0.0 <26.0.0"
@@ -125,6 +126,7 @@
         "gulp-cached": "^1.1.1",
         "gulp-clean": "^0.4.0",
         "gulp-eslint-new": "^2.6.2",
+        "patch-package": "^8.0.1",
         "prettier": "^3.8.3",
         "vitest": "^4.1.5"
     }

--- a/patches/@libp2p+utils+7.1.0.patch
+++ b/patches/@libp2p+utils+7.1.0.patch
@@ -1,0 +1,62 @@
+diff --git a/node_modules/@libp2p/utils/dist/src/queue/job.js b/node_modules/@libp2p/utils/dist/src/queue/job.js
+index 8aef8c4..993ba71 100644
+--- a/node_modules/@libp2p/utils/dist/src/queue/job.js
++++ b/node_modules/@libp2p/utils/dist/src/queue/job.js
+@@ -8,6 +8,16 @@ import { JobRecipient } from "./recipient.js";
+ function randomId() {
+     return `${(parseInt(String(Math.random() * 1e9), 10)).toString()}${Date.now()}`;
+ }
++// Brand placed on the inner onProgress closure built in Job.run so Job.join
++// can recognise — and refuse — a self-referential recipient.
++//
++// Without this brand, a Job whose `fn` propagates `options.onProgress`
++// downstream (as libp2p's dial-queue does through peerRouting/kad-dht/openStream)
++// can re-enter the same Queue and end up calling existingDial.join({ onProgress })
++// where `onProgress` is the running Job's own fan-out closure. That registers
++// the closure as one of its own recipients, and the very next progress event
++// stack-overflows.
++const PROGRESS_OWNER = Symbol.for('@libp2p/utils:queue:progress-owner');
+ export class Job {
+     id;
+     fn;
+@@ -43,6 +53,16 @@ export class Job {
+         }
+     }
+     async join(options) {
++        // If the joiner's onProgress is THIS job's own internal fan-out closure
++        // (reached by re-entering the queue from inside fn — see dial-queue's
++        // existingDial.join path), drop it before constructing the recipient.
++        // The joiner still gets the deferred result via the returned promise;
++        // we just don't wire its closure as a self-recipient that would loop
++        // when the closure next fires.
++        if (options != null && options.onProgress != null && options.onProgress[PROGRESS_OWNER] === this) {
++            const { onProgress, ...rest } = options;
++            options = rest;
++        }
+         const recipient = new JobRecipient(options);
+         this.recipients.push(recipient);
+         options?.signal?.addEventListener('abort', this.onAbort);
+@@ -51,16 +71,18 @@ export class Job {
+     async run() {
+         this.status = 'running';
+         this.timeline.started = Date.now();
++        const onProgress = (evt) => {
++            this.recipients.forEach(recipient => {
++                recipient.onProgress?.(evt);
++            });
++        };
++        onProgress[PROGRESS_OWNER] = this;
+         try {
+             this.controller.signal.throwIfAborted();
+             const result = await raceSignal(this.fn({
+                 ...(this.options ?? {}),
+                 signal: this.controller.signal,
+-                onProgress: (evt) => {
+-                    this.recipients.forEach(recipient => {
+-                        recipient.onProgress?.(evt);
+-                    });
+-                }
++                onProgress
+             }), this.controller.signal);
+             this.recipients.forEach(recipient => {
+                 recipient.deferred.resolve(result);

--- a/src/src/Core.ts
+++ b/src/src/Core.ts
@@ -13,6 +13,7 @@ import {
     LinkThreadRequestData,
     LinkThreadRequestMessage,
 } from './threading/interfaces/thread-messages/messages/LinkThreadRequestMessage.js';
+import { UnlinkThreadMessage } from './threading/interfaces/thread-messages/messages/UnlinkThreadMessage.js';
 import { ThreadMessageBase } from './threading/interfaces/thread-messages/ThreadMessageBase.js';
 import { ThreadTypes } from './threading/thread/enums/ThreadTypes.js';
 import { OPNetIdentity } from './poc/identity/OPNetIdentity.js';
@@ -174,6 +175,21 @@ export class Core extends Logger {
         targetThread.postMessage(msg, [msg.data.port]);
     }
 
+    /**
+     * Forward an UNLINK_THREAD broadcast from one manager to every manager so each
+     * pool can purge dead MessagePorts from its leaf threads' threadRelations.
+     * Triggered when a worker dies inside any Threader (see Threader.ts exit handler).
+     */
+    private onUnlinkThread(msg: UnlinkThreadMessage): void {
+        const types = Object.keys(this.masterThreads) as Array<keyof typeof this.masterThreads>;
+        for (const type of types) {
+            const target = this.masterThreads[type];
+            if (target) {
+                target.postMessage(msg);
+            }
+        }
+    }
+
     private onThreadMessage(
         _thread: Worker,
         msg: ThreadMessageBase<MessageType>,
@@ -187,6 +203,11 @@ export class Core extends Logger {
 
             case MessageType.LINK_THREAD: {
                 this.onLinkThread(msg as LinkThreadMessage<LinkType>);
+                break;
+            }
+
+            case MessageType.UNLINK_THREAD: {
+                this.onUnlinkThread(msg as UnlinkThreadMessage);
                 break;
             }
 

--- a/src/src/poc/mempool/bitcoin-mempool/MempoolManager.ts
+++ b/src/src/poc/mempool/bitcoin-mempool/MempoolManager.ts
@@ -1,4 +1,4 @@
-import { ConfigurableDBManager, Logger } from '@btc-vision/bsi-common';
+import { ConfigurableDBManager, DebugLevel, Logger } from '@btc-vision/bsi-common';
 import { ThreadMessageBase } from '../../../threading/interfaces/thread-messages/ThreadMessageBase.js';
 import { ThreadTypes } from '../../../threading/thread/enums/ThreadTypes.js';
 import { ThreadData } from '../../../threading/interfaces/ThreadData.js';
@@ -19,11 +19,15 @@ import { parseAndStoreInputOutputs } from '../../../utils/TransactionMempoolUtil
 import fs from 'fs';
 import { LargeJSONProcessor } from '../../../utils/LargeJSONProcessor.js';
 import { RPCMessageData } from '../../../threading/interfaces/thread-messages/messages/api/RPCMessage.js';
-import { BitcoinRPCThreadMessageType } from '../../../blockchain-indexer/rpc/thread/messages/BitcoinRPCThreadMessage.js';
+import {
+    BitcoinRPCThreadMessageType
+} from '../../../blockchain-indexer/rpc/thread/messages/BitcoinRPCThreadMessage.js';
 import { TransactionVerifierManager } from '../transaction/TransactionVerifierManager.js';
 import { fromHex, Network } from '@btc-vision/bitcoin';
 import { NetworkConverter } from '../../../config/network/NetworkConverter.js';
-import { OPNetTransactionTypes } from '../../../blockchain-indexer/processor/transaction/enums/OPNetTransactionTypes.js';
+import {
+    OPNetTransactionTypes
+} from '../../../blockchain-indexer/processor/transaction/enums/OPNetTransactionTypes.js';
 import { getMongodbMajorVersion } from '../../../vm/storage/databases/MongoUtils.js';
 import { MongoDBConfigurationDefaults } from '../../../vm/storage/databases/MongoDBConfigurationDefaults.js';
 
@@ -202,7 +206,7 @@ export class MempoolManager extends Logger {
             const batchData = await Promise.safeAll(promises);
             txsData.push(...batchData.filter((tx) => !!tx));
 
-            if (Config.DEV_MODE) {
+            if (Config.DEV_MODE && Config.DEBUG_LEVEL >= DebugLevel.TRACE) {
                 this.log(
                     `Fetched batch ${Math.floor(i / Config.MEMPOOL.BATCH_SIZE) + 1} of ${Math.ceil(
                         txs.length / Config.MEMPOOL.BATCH_SIZE,

--- a/src/src/threading/Threader.ts
+++ b/src/src/threading/Threader.ts
@@ -15,6 +15,7 @@ import {
     LinkThreadRequestMessage,
 } from './interfaces/thread-messages/messages/LinkThreadRequestMessage.js';
 import { SetMessagePort } from './interfaces/thread-messages/messages/SetMessagePort.js';
+import { UnlinkThreadMessage } from './interfaces/thread-messages/messages/UnlinkThreadMessage.js';
 import { ThreadMessageBase } from './interfaces/thread-messages/ThreadMessageBase.js';
 import { ThreadData } from './interfaces/ThreadData.js';
 import { ThreaderConfigurations } from './interfaces/ThreaderConfigurations.js';
@@ -25,6 +26,7 @@ import { FastStringMap } from '../utils/fast/FastStringMap.js';
 export type ThreadTaskCallback = {
     timeout: ReturnType<typeof setTimeout>;
     resolve: (value: ThreadData | PromiseLike<ThreadData>) => void;
+    port?: MessagePort;
 };
 
 export class Threader<T extends ThreadTypes> extends Logger {
@@ -194,6 +196,17 @@ export class Threader<T extends ThreadTypes> extends Logger {
         }
     }
 
+    /**
+     * Forward an UNLINK_THREAD notice to every sub-worker in this manager's pool
+     * so each leaf Thread can drop the dead MessagePort from its threadRelations.
+     * Called by ThreadManager when Core fans the notice out to all managers.
+     */
+    public broadcastUnlinkThread(msg: UnlinkThreadMessage): void {
+        for (const thread of this.threads) {
+            this.executeMessageOnThreadNoResponse(msg, thread);
+        }
+    }
+
     public createChannel(): { tx: MessagePort; rx: MessagePort } {
         const channel = new MessageChannel();
 
@@ -277,10 +290,42 @@ export class Threader<T extends ThreadTypes> extends Logger {
                             `Thread #${i} died. {Target: ${this.target} | ExitCode -> ${exitCode}}\n`,
                         );
 
+                        const deadThreadId = thread.threadId;
+
                         // Find the correct thread by its ID in the array
-                        const idx = this.threads.findIndex((w) => w.threadId === thread.threadId);
+                        const idx = this.threads.findIndex((w) => w.threadId === deadThreadId);
                         if (idx > -1) {
                             this.threads.splice(idx, 1); // remove just that one
+                        }
+
+                        // Drop the dead worker's subChannel so we never try to post to it again.
+                        this.subChannels.delete(deadThreadId);
+
+                        // Cancel any in-flight manager-side tasks targeted at this dead worker.
+                        for (const taskId of [...this.tasks.keys()]) {
+                            const task = this.tasks.get(taskId);
+                            if (task) {
+                                clearTimeout(task.timeout);
+                                task.resolve({ error: true });
+                                this.tasks.delete(taskId);
+                            }
+                        }
+
+                        // Notify the rest of the cluster so peers drop dead ports for this id.
+                        // Without this, leaf Thread instances keep the dead MessagePort in
+                        // their threadRelations and every send to it stalls 240s.
+                        const unlinkMsg: UnlinkThreadMessage = {
+                            type: MessageType.UNLINK_THREAD,
+                            toServer: false,
+                            data: {
+                                threadType: this.threadType,
+                                threadId: deadThreadId,
+                            },
+                        };
+                        try {
+                            parentPort?.postMessage(unlinkMsg);
+                        } catch (e) {
+                            this.error(`Failed to broadcast UNLINK_THREAD: ${(e as Error).stack}`);
                         }
 
                         // Then re-create a new thread instance

--- a/src/src/threading/enum/MessageType.ts
+++ b/src/src/threading/enum/MessageType.ts
@@ -3,6 +3,7 @@ export enum MessageType {
     LINK_THREAD,
     SET_MESSAGE_PORT,
     LINK_THREAD_REQUEST,
+    UNLINK_THREAD,
     RPC_METHOD,
 
     BLOCK_PROCESSED,

--- a/src/src/threading/interfaces/thread-messages/messages/UnlinkThreadMessage.ts
+++ b/src/src/threading/interfaces/thread-messages/messages/UnlinkThreadMessage.ts
@@ -1,0 +1,13 @@
+import { MessageType } from '../../../enum/MessageType.js';
+import { ThreadTypes } from '../../../thread/enums/ThreadTypes.js';
+import { ThreadMessageBase } from '../ThreadMessageBase.js';
+
+export interface UnlinkThreadData {
+    readonly threadType: ThreadTypes;
+    readonly threadId: number;
+}
+
+export interface UnlinkThreadMessage extends ThreadMessageBase<MessageType.UNLINK_THREAD> {
+    readonly type: MessageType.UNLINK_THREAD;
+    readonly data: UnlinkThreadData;
+}

--- a/src/src/threading/manager/ThreadManager.ts
+++ b/src/src/threading/manager/ThreadManager.ts
@@ -6,6 +6,7 @@ import {
     LinkType,
 } from '../interfaces/thread-messages/messages/LinkThreadMessage.js';
 import { LinkThreadRequestMessage } from '../interfaces/thread-messages/messages/LinkThreadRequestMessage.js';
+import { UnlinkThreadMessage } from '../interfaces/thread-messages/messages/UnlinkThreadMessage.js';
 import { ThreadMessageBase } from '../interfaces/thread-messages/ThreadMessageBase.js';
 import { ThreadTypes } from '../thread/enums/ThreadTypes.js';
 import { Threader } from '../Threader.js';
@@ -100,6 +101,10 @@ export abstract class ThreadManager<T extends ThreadTypes> extends Logger {
             }
             case MessageType.LINK_THREAD: {
                 await this.onLinkThread(msg as LinkThreadMessage<LinkType>);
+                break;
+            }
+            case MessageType.UNLINK_THREAD: {
+                this.threadManager.broadcastUnlinkThread(msg as UnlinkThreadMessage);
                 break;
             }
             default: {

--- a/src/src/threading/thread/Thread.ts
+++ b/src/src/threading/thread/Thread.ts
@@ -7,6 +7,7 @@ import {
 } from '../interfaces/thread-messages/messages/LinkThreadMessage.js';
 import { SetMessagePort } from '../interfaces/thread-messages/messages/SetMessagePort.js';
 import { ThreadMessageResponse } from '../interfaces/thread-messages/messages/ThreadMessageResponse.js';
+import { UnlinkThreadMessage } from '../interfaces/thread-messages/messages/UnlinkThreadMessage.js';
 import { ThreadMessageBase } from '../interfaces/thread-messages/ThreadMessageBase.js';
 import { ThreadData } from '../interfaces/ThreadData.js';
 import { ThreadTaskCallback } from '../Threader.js';
@@ -35,6 +36,12 @@ export abstract class Thread<T extends ThreadTypes> extends Logger implements IT
     private tasks: FastStringMap<ThreadTaskCallback> = new FastStringMap<ThreadTaskCallback>();
     private availableThreads: Partial<Record<ThreadTypes, number>> = {};
 
+    // Tracks the other-end identity for each linked MessagePort so UNLINK_THREAD
+    // can identify which port to drop without depending on the (inconsistent)
+    // keying of threadRelations across RX/TX link messages.
+    private portMeta: Map<MessagePort, { threadType: ThreadTypes; threadId: number }> =
+        new Map();
+
     protected constructor() {
         super();
 
@@ -49,14 +56,9 @@ export abstract class Thread<T extends ThreadTypes> extends Logger implements IT
     ): Promise<ThreadData | null> {
         return new Promise(async (resolve, reject) => {
             try {
-                const relation = this.threadRelations[threadType];
-                if (relation) {
-                    const port = this.getNextAvailableThread(threadType);
-                    if (!port) {
-                        return null;
-                    }
-
-                    const d = await this.sendMessage(m, port);
+                const port = this.getNextAvailableThread(threadType);
+                if (port) {
+                    const d = await this.sendMessage(m, port, threadType);
                     resolve(d);
                 } else if (i !== 5 && allowRetries) {
                     setTimeout(async () => {
@@ -93,7 +95,7 @@ export abstract class Thread<T extends ThreadTypes> extends Logger implements IT
                 if (relation) {
                     const promises: Promise<ThreadData | null>[] = [];
                     for (const port of relation) {
-                        promises.push(this.sendMessage({ ...m }, port));
+                        promises.push(this.sendMessage({ ...m }, port, threadType));
                     }
 
                     await Promise.safeAll(promises);
@@ -116,6 +118,7 @@ export abstract class Thread<T extends ThreadTypes> extends Logger implements IT
     protected async sendMessage(
         m: ThreadMessageBase<MessageType>,
         port: MessagePort,
+        destThreadType?: ThreadTypes,
     ): Promise<ThreadData | null> {
         return new Promise<ThreadData | null>((resolve, reject) => {
             try {
@@ -123,15 +126,22 @@ export abstract class Thread<T extends ThreadTypes> extends Logger implements IT
                 if (!hasTaskId) {
                     m.taskId = this.generateTaskId();
 
+                    const sentAt = Date.now();
+                    const portIndex = destThreadType
+                        ? this.threadRelationsArray[destThreadType]?.indexOf(port) ?? -1
+                        : -1;
+
                     const timeout = setTimeout(() => {
+                        const ageMs = Date.now() - sentAt;
+                        const inflight = this.tasks.size;
                         this.warn(
-                            `[B] Thread task ${m.taskId} timed out. (Thread: ${threadId}, ThreadType: ${this.threadType}) - Trace: ${JSON.stringify(m.data)}`,
+                            `[B] Thread task ${m.taskId} timed out after ${ageMs}ms. (Thread: ${threadId}, ThreadType: ${this.threadType} -> ${destThreadType ?? 'unknown'} portIdx=${portIndex}, msgType=${m.type}, inflight=${inflight}) - Trace: ${JSON.stringify(m.data)}`,
                         );
 
                         if (Config.DEV.SAVE_TIMEOUTS_TO_FILE) {
                             fs.appendFileSync(
                                 './thread-timeouts.log',
-                                `[B] Thread task ${m.taskId} timed out. (Thread: ${threadId}, ThreadType: ${this.threadType}) - Trace: ${JSON.stringify(m)}\n`,
+                                `[B] Thread task ${m.taskId} timed out after ${ageMs}ms. (Thread: ${threadId}, ThreadType: ${this.threadType} -> ${destThreadType ?? 'unknown'} portIdx=${portIndex}, msgType=${m.type}, inflight=${inflight}) - Trace: ${JSON.stringify(m)}\n`,
                             );
                         }
 
@@ -141,6 +151,7 @@ export abstract class Thread<T extends ThreadTypes> extends Logger implements IT
                     const task: ThreadTaskCallback = {
                         timeout: timeout,
                         resolve: resolve,
+                        port: port,
                     };
 
                     this.tasks.set(m.taskId, task);
@@ -185,11 +196,11 @@ export abstract class Thread<T extends ThreadTypes> extends Logger implements IT
 
     private getNextAvailableThread(threadType: ThreadTypes): MessagePort | null {
         const relation = this.threadRelationsArray[threadType];
-        if (!relation) {
+        if (!relation || relation.length === 0) {
             return null;
         }
 
-        const currentIndex = this.availableThreads[threadType] || 0;
+        const currentIndex = (this.availableThreads[threadType] || 0) % relation.length;
         this.availableThreads[threadType] = (currentIndex + 1) % relation.length;
 
         return relation[currentIndex];
@@ -218,6 +229,9 @@ export abstract class Thread<T extends ThreadTypes> extends Logger implements IT
             case MessageType.LINK_THREAD:
                 this.createInternalThreadLink(m as LinkThreadMessage<LinkType>);
                 break;
+            case MessageType.UNLINK_THREAD:
+                this.onUnlinkThread(m as UnlinkThreadMessage);
+                break;
             default:
                 await this.onMessage(m);
                 break;
@@ -243,7 +257,79 @@ export abstract class Thread<T extends ThreadTypes> extends Logger implements IT
         this.threadRelationsArray[threadType] = array;
         this.threadRelations[threadType] = relation;
 
+        // sourceThreadType / sourceThreadId always describe the OTHER end of the
+        // link from this thread's perspective, regardless of TX/RX direction.
+        this.portMeta.set(data.port, {
+            threadType: data.sourceThreadType,
+            threadId: data.sourceThreadId,
+        });
+
         this.createEvents(threadType, data.port);
+    }
+
+    /**
+     * Drop every link to a worker that just died.
+     *
+     * Without this, the dead MessagePort lingers in threadRelations /
+     * threadRelationsArray and every subsequent send to that port stalls until
+     * the 240s sendMessage timeout fires — and on broadcast paths
+     * (sendMessageToAllThreads) the slowest dead port poisons the whole call.
+     * In-flight tasks pinned to the dead port are also resolved here so callers
+     * unblock immediately instead of waiting out their own 240s timer.
+     */
+    private onUnlinkThread(m: UnlinkThreadMessage): void {
+        const { threadType, threadId } = m.data;
+
+        const deadPorts: MessagePort[] = [];
+        for (const [port, meta] of this.portMeta) {
+            if (meta.threadType === threadType && meta.threadId === threadId) {
+                deadPorts.push(port);
+            }
+        }
+
+        if (deadPorts.length === 0) return;
+
+        for (const port of deadPorts) {
+            this.portMeta.delete(port);
+
+            const array = this.threadRelationsArray[threadType];
+            if (array) {
+                const idx = array.indexOf(port);
+                if (idx >= 0) array.splice(idx, 1);
+            }
+
+            const relation = this.threadRelations[threadType];
+            if (relation) {
+                for (const [k, v] of relation.entries()) {
+                    if (v === port) relation.delete(k);
+                }
+            }
+
+            try {
+                port.close();
+            } catch {
+                // closing an already-disposed port is harmless; ignore.
+            }
+        }
+
+        const deadSet = new Set(deadPorts);
+        let cancelled = 0;
+        for (const taskId of [...this.tasks.keys()]) {
+            const task = this.tasks.get(taskId);
+            if (task && task.port && deadSet.has(task.port)) {
+                clearTimeout(task.timeout);
+                task.resolve(null);
+                this.tasks.delete(taskId);
+                cancelled++;
+            }
+        }
+
+        // Reset round-robin cursor so we don't read past the new (shorter) array.
+        this.availableThreads[threadType] = 0;
+
+        this.warn(
+            `Unlinked dead ${threadType}#${threadId}: dropped ${deadPorts.length} port(s), cancelled ${cancelled} pending task(s).`,
+        );
     }
 
     private async onEventMessage(

--- a/tests/libp2p/queueSelfJoin.test.ts
+++ b/tests/libp2p/queueSelfJoin.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect } from 'vitest';
+import { Queue } from '@libp2p/utils';
+
+/**
+ * Reproduces the @libp2p/utils Queue self-recipient cycle that crashed our P2P worker.
+ *
+ * Real-world chain:
+ *   dial(peerX, {onProgress: ext})
+ *     → Job_X = queue.add(dialFn, {onProgress: ext})
+ *     → Job_X.run() builds inner_X = (evt) => recipients.forEach(r => r.onProgress?.(evt))
+ *     → dialFn({...opts, onProgress: inner_X})
+ *       → calculateMultiaddrs → peerRouting.findPeer(peerX, {onProgress: inner_X})
+ *         → kad-dht queryManager → query-path → query()
+ *           → network.sendRequest(peerX, FIND_NODE, {onProgress: inner_X})
+ *             → openStream(peerX) → openConnection(peerX)
+ *               → dialQueue.dial(peerX, {onProgress: inner_X})
+ *                 → existingDial = Job_X (same job!)
+ *                 → existingDial.join({onProgress: inner_X})
+ *                   → Job_X.recipients.push({onProgress: inner_X})
+ *
+ * Now Job_X.recipients contains a recipient whose onProgress IS Job_X's own
+ * fan-out closure. The next time inner_X fires, it iterates recipients, calls
+ * inner_X again, iterates again, ... → RangeError: Maximum call stack size.
+ *
+ * This test reduces the chain to its essence: a job that joins itself with
+ * its own inner onProgress, then fires a progress event.
+ */
+describe('@libp2p/utils Queue self-recipient cycle', () => {
+    it('infinite-recurses when a job is self-joined with its own inner onProgress', async () => {
+        const queue = new Queue<void, { onProgress?: (evt: Event) => void }>();
+
+        let observedError: unknown;
+        try {
+            await queue.add(
+                (opts) => {
+                    // While running, a Job stays at the head of queue.queue (see
+                    // @libp2p/utils/dist/src/queue/index.js:78-83). This is the same
+                    // mechanism dialQueue.dial uses to find an "existingDial".
+                    const runningJob = (queue as unknown as { queue: Array<{ join: (o: unknown) => Promise<void> }> }).queue[0];
+
+                    // Replicate dial-queue.js:123 — `existingDial.join(options)`
+                    // where options.onProgress is the running job's own inner_X
+                    // (here: opts.onProgress, which Job.run set to inner_X before
+                    // invoking us).
+                    void runningJob.join({ onProgress: opts.onProgress });
+
+                    // Fire any progress event. Without the fix this self-recurses
+                    // through inner_X → recipients.forEach → inner_X → ...
+                    opts.onProgress?.(new Event('repro'));
+                },
+                { onProgress: () => {} },
+            );
+        } catch (err) {
+            observedError = err;
+        }
+
+        // BEFORE FIX: Job.run catches the synchronous RangeError thrown out of fn
+        // and rejects the joiner's deferred with it.
+        // AFTER FIX: no recursion — queue.add resolves cleanly.
+        expect(observedError).toBeUndefined();
+    });
+
+    it('still fans progress events out to all distinct external recipients', async () => {
+        const queue = new Queue<void, { onProgress?: (evt: Event) => void }>();
+        const seenA: string[] = [];
+        const seenB: string[] = [];
+
+        let resolveSecondJoined: () => void = () => {};
+        const secondJoined = new Promise<void>((resolve) => {
+            resolveSecondJoined = resolve;
+        });
+
+        const first = queue.add(
+            async (opts) => {
+                // Wait until the second caller has joined this same job, then
+                // fire one progress event — both recipients must observe it.
+                await secondJoined;
+                opts.onProgress?.(new Event('hello'));
+            },
+            {
+                onProgress: (evt) => {
+                    seenA.push(evt.type);
+                },
+            },
+        );
+
+        const runningJob = (
+            queue as unknown as { queue: Array<{ join: (o: unknown) => Promise<void> }> }
+        ).queue[0];
+
+        const second = runningJob.join({
+            onProgress: (evt: Event) => {
+                seenB.push(evt.type);
+            },
+        });
+
+        resolveSecondJoined();
+        await Promise.all([first, second]);
+
+        expect(seenA).toEqual(['hello']);
+        expect(seenB).toEqual(['hello']);
+    });
+});


### PR DESCRIPTION
## Description

Introduce UNLINK_THREAD handling to detect and remove dead MessagePorts and avoid long stalled sends. Adds a new UnlinkThreadMessage interface and MessageType.UNLINK_THREAD. Core now fans out unlink notices to all managers; ThreadManager forwards to its Threader; Threader broadcasts unlink to child workers and posts unlink to parent when a child exits (also deletes subChannels and cancels in-flight tasks). Thread tracks port metadata (portMeta), removes/ closes dead ports from threadRelations and threadRelationsArray, cancels pending tasks bound to those ports, and resets round-robin cursors. Also improves sendMessage timeout logging and records the target port on tasks so they can be cancelled when a peer dies.

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Performance improvement
- [ ] Consensus change (changes that affect state calculation or validation)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] CI/CD changes
- [ ] Dependencies update

## Checklist

### Build & Tests

- [ ] `npm install` completes without errors
- [ ] `npm run build` completes without errors
- [ ] `npm test` passes all tests

### Code Quality

- [ ] Code follows the project's coding standards
- [ ] No new compiler warnings introduced
- [ ] Error handling is appropriate
- [ ] Logging is appropriate for debugging and monitoring

### Documentation

- [ ] Code comments added for complex logic
- [ ] Public APIs are documented
- [ ] README updated (if applicable)

### Security

- [ ] No sensitive data (keys, credentials) committed
- [ ] No new security vulnerabilities introduced
- [ ] RPC endpoints properly authenticated
- [ ] Input validation in place for external data

### OP_NET Node Specific

- [ ] Changes are compatible with existing network state
- [ ] Consensus logic changes are documented and tested
- [ ] State transitions are deterministic
- [ ] WASM VM execution is reproducible across nodes
- [ ] P2P protocol changes are backward-compatible (or migration planned)
- [ ] Database schema changes include migration path
- [ ] Epoch finality and PoC/PoW logic unchanged (or documented if changed)

## Testing

<!-- Describe how you tested these changes -->

## Consensus Impact

<!-- If this PR affects consensus, describe the impact and testing methodology -->

## Related Issues

<!-- Link any related issues: Fixes #123, Relates to #456 -->

---
By submitting this PR, I confirm that my contribution is made under the terms of the project's license.
